### PR TITLE
misc: Add different intervals for identify after invalid session

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -237,10 +237,18 @@ class WebSocketShard extends EventEmitter {
       case OPCodes.RECONNECT:
         return this.reconnect();
       case OPCodes.INVALID_SESSION:
-        if (!packet.d) this.sessionID = null;
         this.sequence = -1;
         this.debug('Session invalidated');
-        return this.identify(!packet.d ? 2500 : 0);
+        // If the session isn't resumable
+        if (!packet.d) {
+          // If we had a session ID before
+          if (this.sessionID) {
+            this.sessionID = null;
+            return this.identify(2500);
+          }
+          return this.identify(5000);
+        }
+        return this.identify();
       case OPCodes.HEARTBEAT_ACK:
         return this.ackHeartbeat();
       case OPCodes.HEARTBEAT:


### PR DESCRIPTION
- 2500 if we couldn't resume in time
- 5000 if we didn't have a session ID (per the docs on identify, that a client can only connect every 5 seconds)
- Otherwise, just identify again

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
